### PR TITLE
Pause S3 Source polls when no data

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=2.13.11
+version=2.14.0
 
 sonatypeUsername=<fill>
 sonatypePassword=<fill>

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -78,7 +78,7 @@ public class S3SinkTask extends SinkTask {
     @Override
     public void put(final Collection<SinkRecord> records) throws ConnectException {
         Objects.requireNonNull(records, "records cannot be null");
-        LOGGER.info("Processing {} records", records.size());
+        LOGGER.debug("Processing {} records", records.size());
         records.forEach(recordGrouper :: put);
     }
 

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SourceConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SourceConfig.java
@@ -14,6 +14,8 @@ public class S3SourceConfig extends AivenCommonS3Config {
 
     public static final String BATCH_SIZE_CONFIG = "batch.size";
 
+    public static final String EMPTY_POLL_DELAY_MS = "poll.delay.empty.ms";
+
     public static final String FILES_PAGE_SIZE_CONFIG = "files.page.size";
 
     public static final String GROUP_S3Config = "S3Config";
@@ -38,6 +40,8 @@ public class S3SourceConfig extends AivenCommonS3Config {
     public int getBatchSize() {
         return getInt(BATCH_SIZE_CONFIG);
     }
+
+    public int getEmptyPollDelayMs() { return getInt(EMPTY_POLL_DELAY_MS); }
 
     public int getFilesPageSize() {
         return getInt(FILES_PAGE_SIZE_CONFIG);
@@ -99,6 +103,18 @@ public class S3SourceConfig extends AivenCommonS3Config {
                 groupOrder++,
                 ConfigDef.Width.NONE,
                 FILES_PAGE_SIZE_CONFIG);
+
+        configDef.define(
+                EMPTY_POLL_DELAY_MS,
+                ConfigDef.Type.INT,
+                500,
+                ConfigDef.Range.between(0, 600000),
+                ConfigDef.Importance.MEDIUM,
+                "The amount of time (in milliseconds) to wait before polling for more messages when the previous batch returned no results",
+                GROUP_Connector,
+                groupOrder++,
+                ConfigDef.Width.NONE,
+                EMPTY_POLL_DELAY_MS);
     }
 
     protected static void addS3SourceConfigGroup(final ConfigDef configDef) {


### PR DESCRIPTION
## Changes

When an S3 Source `poll()` returns no records, pause for a specified amount of time (`500ms` by default) to avoid polling an S3 bucket like crazy